### PR TITLE
[Upgrade] Testnet Release Nov. 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.dependencies]
-snarkvm = { git = "https://github.com/AleoNet/snarkVM.git", rev = "02994a1" }
+snarkvm = { git = "https://github.com/AleoNet/snarkVM.git", rev = "0b391d2" }
 #snarkvm = { path = "../snarkVM" }
 
 [profile.release]


### PR DESCRIPTION
Upgrading `snarkVM` rev for Testnet release