### PR TITLE
[Upgrade] Canary Release Nov. 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.dependencies]
-snarkvm = { git = "https://github.com/AleoNet/snarkVM.git", rev = "02994a1" }
+snarkvm = { git = "https://github.com/AleoNet/snarkVM.git", rev = "d432417" }
 #snarkvm = { path = "../snarkVM" }
 
 [profile.release]


### PR DESCRIPTION
Upgrading `canary` branch to latest snarkVM rev used for Canary