### PR TITLE
[Upgrade] Mainnet Release Dec. 3, 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ members = [
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-#rev = "1de86e7"
-version = "=1.1.0"
+rev = "4965f6b"
 #snarkvm = { path = "../snarkVM" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,11 @@ members = [
 ]
 
 [workspace.dependencies]
-snarkvm = { git = "https://github.com/AleoNet/snarkVM.git", rev = "1de86e7" }
+
+[workspace.dependencies.snarkvm]
+git = "https://github.com/AleoNet/snarkVM.git"
+#rev = "1de86e7"
+version = "=1.1.0"
 #snarkvm = { path = "../snarkVM" }
 
 [profile.release]


### PR DESCRIPTION
Switching `snarkVM` to use latest `4965f6b` rev for mainnet release. 