### PR TITLE
[Upgrade] - Update snarkVM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ members = [
 ]
 
 [workspace.dependencies]
-smallvec = "=1.14.0"
 
 [workspace.dependencies.snarkvm]
 #git = "https://github.com/ProvableHQ/snarkVM.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,12 @@ members = [
 ]
 
 [workspace.dependencies]
+smallvec = "=1.14.0"
 
 [workspace.dependencies.snarkvm]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "54c368c33"
-#version = "=3.8.0"
+#git = "https://github.com/ProvableHQ/snarkVM.git"
+#rev = "54c368c33"
+version = "=4.0.0"
 #snarkvm = { path = "../snarkVM" }
 
 [profile.release]


### PR DESCRIPTION
# Motivation
Upgrading snarkVM version to v4.0.0 in preparation to mainnet upgrade scheduled for Tuesday, July 22nd 2025